### PR TITLE
[MARK-108] 현재 워크스페이스 분기 처리

### DIFF
--- a/DevMark/app/src/main/java/com/devmark/devmark/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/DevMark/app/src/main/java/com/devmark/devmark/data/repository/UserPreferencesRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.devmark.devmark.data.repository
 
 import android.content.Context
-import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.devmark.devmark.data.utils.LoggerUtils
@@ -19,11 +19,11 @@ val Context.userDataStore: DataStore<Preferences> by preferencesDataStore(
 
 class UserPreferencesRepositoryImpl: UserPreferencesRepository {
     private val userDataStorePreferences: DataStore<Preferences> = app.applicationContext.userDataStore
-    private val tag = "UserPreferences"
 
     private companion object {
         private val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")
         private val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
+        private val CURRENT_WORKSPACE = intPreferencesKey("current_workspace")
     }
 
     override suspend fun clearData(): Result<Boolean> {
@@ -71,6 +71,25 @@ class UserPreferencesRepositoryImpl: UserPreferencesRepository {
                 preferences[REFRESH_TOKEN_KEY] ?: ""
             }.first()
             Result.success(refreshToken)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun setCurrentWorkspace(workspaceId: Int) {
+        LoggerUtils.debug("setCurrentWorkspace 호출")
+        userDataStorePreferences.edit { preferences ->
+            preferences[CURRENT_WORKSPACE] = workspaceId
+        }
+    }
+
+    override suspend fun getCurrentWorkspace(): Result<Int> {
+        LoggerUtils.debug("getCurrentWorkspace 호출")
+        return try {
+            val currentWorkspaceId = userDataStorePreferences.data.map { preferences ->
+                preferences[CURRENT_WORKSPACE] ?: -1
+            }.first()
+            Result.success(currentWorkspaceId)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/DevMark/app/src/main/java/com/devmark/devmark/domain/repository/UserPreferencesRepository.kt
+++ b/DevMark/app/src/main/java/com/devmark/devmark/domain/repository/UserPreferencesRepository.kt
@@ -10,4 +10,8 @@ interface UserPreferencesRepository {
     suspend fun setRefreshToken(refreshToken: String)
 
     suspend fun getRefreshToken(): Result<String>
+
+    suspend fun setCurrentWorkspace(workspaceId: Int)
+
+    suspend fun getCurrentWorkspace(): Result<Int>
 }

--- a/DevMark/app/src/main/java/com/devmark/devmark/presentation/view/workspace_select/SelectWorkSpaceViewModel.kt
+++ b/DevMark/app/src/main/java/com/devmark/devmark/presentation/view/workspace_select/SelectWorkSpaceViewModel.kt
@@ -19,6 +19,9 @@ class SelectWorkSpaceViewModel : ViewModel() {
     private val _uiState = MutableLiveData<UiState<List<WorkspaceEntity>>>(UiState.Loading)
     val uiState: LiveData<UiState<List<WorkspaceEntity>>> get() = _uiState
 
+    private var _currentWorkspace = MutableLiveData<WorkspaceEntity>(WorkspaceEntity(id = -1, name = "", description = "", bookmarkCount = 0, userCount = 0))
+    val currentWorkspace get() = _currentWorkspace
+
     fun fetchData() {
         _uiState.value = UiState.Loading
 
@@ -26,7 +29,9 @@ class SelectWorkSpaceViewModel : ViewModel() {
             val accessToken = app.userPreferences.getAccessToken().getOrNull().orEmpty()
             userRepositoryImpl.getWorkspaceList(accessToken)
                 .onSuccess {
-                    _uiState.value = UiState.Success(it.workspaces)
+                    val (newList, currentWorkspaceList) = it.workspaces.partition { item -> item.id != app.userPreferences.getCurrentWorkspace().getOrNull()}
+                    if(currentWorkspaceList.isNotEmpty()) _currentWorkspace.value = currentWorkspaceList.first()
+                    _uiState.value = UiState.Success(newList)
                 }.onFailure {
                     _uiState.value = UiState.Failure(it.message)
                 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 , MARK-108

## 📝작업 내용

> 로컬에 마지막에 입장한 워크스페이스의 아이디를 저장한 뒤
> 이후 목록 조회 시 저장된 아이디로 리스트를 partition을 사용해 분리 시켜 적용
> 리사이클러뷰에는 현재 워크스페이스가 제외된 리스트가 적용됨


